### PR TITLE
Patches for iframe-based uploads to Amazon S3

### DIFF
--- a/source/Uploader.js
+++ b/source/Uploader.js
@@ -91,8 +91,8 @@ var Uploader = new Class({
 				
 		var align = (Browser.Engine.trident) ? 'left' : 'right';
 		doc.body.innerHTML = '<form method="post" enctype="multipart/form-data" id="form">' +
-			'<input type="file" id="file" style="position:absolute;' + align + ':0;top:0" />' +
-			'<input type="submit" /><div id="data"></div></form>' + 
+			'<input type="submit" /><div id="data"></div>' +
+			'<input type="file" id="file" style="position:absolute;' + align + ':0;top:0" /></form>' +
 			'<style type="text/css">*{margin:0;padding:0;border:0;overflow:hidden;cursor:pointer;}</style>';
 		
 		this.doc = doc;
@@ -336,7 +336,7 @@ Uploader.File = new Class({
 		var form = doc.forms[0];
 		form.action = merged.url;
 
-		var input = form.elements[0];
+		var input = form.elements[form.elements.length - 1];
 		input.name = merged.fieldName || 'Filedata';
 
 		this.status = Uploader.STATUS_RUNNING;

--- a/source/Uploader.js
+++ b/source/Uploader.js
@@ -274,14 +274,18 @@ Uploader.File = new Class({
 
 		this.status = Uploader.STATUS_COMPLETE;
 
-		var win = new Window(this.iframe.contentWindow);
-		var doc = new Document(win.document);
-		
-		this.response = {
-			window: win,
-			document: doc,
-			text: doc.innerHTML || ''
-		};
+		try {
+			var win = new Window(this.iframe.contentWindow);
+			var doc = new Document(win.document);
+			
+			this.response = {
+				window: win,
+				document: doc,
+				text: doc.innerHTML || ''
+			};
+		} catch(e) {
+			this.response = {};
+		}
 
 		this.base.uploading--;
 		this.dates.complete = new Date();


### PR DESCRIPTION
Hi, I've been using your iframe-based uploader to send files to Amazon S3 [direct from the browser](http://docs.amazonwebservices.com/AmazonS3/latest/dev/UsingHTTPPOST.html) and I've had to make a couple of small patches.

The first was to move the file input to the end of the form so that the file is the last field submitted: Amazon insist on this as they want to process your credentials and object parameters before they start processing your file data. 

The second was to work around cross-domain iframe errors. If the upload is successful Amazon redirect the browser to a URL of your choosing so everything works fine. If the upload fails, however, Amazon don't redirect and so the iframe onLoad code throws a permission denied error when trying to read the iframe properties. I've wrapped this in a try ... catch and just create an empty file.response object if there's an error. You might have a better suggestion for how to handle this condition, but I think it's preferable to catch the error and let the calling code deal with it than to let it propagate.

Thanks for the awesome library!  
