### PR TITLE
Fix for "Timeout #0" issue on Mac platform

### DIFF
--- a/source/Swiff.Uploader.js
+++ b/source/Swiff.Uploader.js
@@ -46,7 +46,7 @@ Swiff.Uploader = new Class({
 		fileSizeMin: 1,
 		fileSizeMax: null, // Official limit is 100 MB for FileReference, but I tested up to 2Gb!
 		allowDuplicates: false,
-		timeLimit: (Browser.Platform.linux) ? 0 : 30,
+		timeLimit: (Browser.Platform.linux || Browser.Platform.mac) ? 0 : 30,
 
 		policyFile: null,
 		buttonImage: null,


### PR DESCRIPTION
Per 3.0 release notes: Added: Option timeLimit (default 30s, 0 for linux). Prevents frozen upload when server fails, after timeout the upload is cancelled and the complete event fired (with “timeout” error).

This is also required on OSX, so I've fixed that here.
